### PR TITLE
Migrate from .NET 8 to 9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -32,4 +32,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: artifact
-        path: JustDanceNextPlus/bin/Release/net8.0/Publish
+        path: JustDanceNextPlus/bin/Release/net9.0/Publish

--- a/JustDanceNextPlus/JustDanceNextPlus.csproj
+++ b/JustDanceNextPlus/JustDanceNextPlus.csproj
@@ -14,12 +14,13 @@
 		<PackageReference Include="HotChocolate.AspNetCore" Version="14.0.0" />
 		<PackageReference Include="HotChocolate.AspNetCore.Voyager" Version="10.5.5" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.10" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+		<PackageReference Include="Scalar.AspNetCore" Version="2.0.26" />
 		<PackageReference Include="SharpZipLib" Version="1.4.2" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
 		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
 	</ItemGroup>

--- a/JustDanceNextPlus/JustDanceNextPlus.csproj
+++ b/JustDanceNextPlus/JustDanceNextPlus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<HotChocolateImplicitUsings>disable</HotChocolateImplicitUsings>

--- a/JustDanceNextPlus/Program.cs
+++ b/JustDanceNextPlus/Program.cs
@@ -7,9 +7,12 @@ using JustDanceNextPlus.JustDanceClasses.GraphQL;
 using JustDanceNextPlus.Services;
 using JustDanceNextPlus.Utilities;
 
+using Microsoft.AspNetCore.OpenApi;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.EntityFrameworkCore;
+
+using Scalar.AspNetCore;
 
 namespace JustDanceNextPlus;
 
@@ -49,9 +52,9 @@ public class Program
 		// Add controllers
 		builder.Services.AddControllers();
 
-		// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+		// Learn more about configuring OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 		builder.Services.AddEndpointsApiExplorer();
-		builder.Services.AddSwaggerGen();
+        builder.Services.AddOpenApi();
 
 		// Allow gzip compression.
 		builder.Services.AddResponseCompression(options =>
@@ -142,11 +145,11 @@ public class Program
 
 	private static void ConfigureMiddleware(WebApplication app)
 	{
-		if (app.Environment.IsDevelopment())
+        if (app.Environment.IsDevelopment())
 		{
-			app.UseSwagger();
-			app.UseSwaggerUI();
-		}
+            app.MapOpenApi();
+            app.MapScalarApiReference();
+        }
 
 		app.UseHttpsRedirection();
 		app.UseResponseCompression();

--- a/JustDanceNextPlus/Program.cs
+++ b/JustDanceNextPlus/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.OpenApi;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.FileProviders;
 
 using Scalar.AspNetCore;
 
@@ -160,13 +161,23 @@ public class Program
 		provider.Mappings[".webm"] = "video/webm";
 		provider.Mappings[".opus"] = "audio/opus";
 
-		app.UseStaticFiles(new StaticFileOptions
+        // Serve static files.
+        app.UseStaticFiles(new StaticFileOptions
 		{
 			ContentTypeProvider = provider
 		});
 
-		// Cache static files if not in development environment.
-		if (!app.Environment.IsDevelopment())
+        // Add external maps middleware
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = new PhysicalFileProvider(
+                app.Configuration["Paths:MapsPath"]!),
+            RequestPath = "/maps",
+            ContentTypeProvider = provider
+        });
+
+        // Cache static files if not in development environment.
+        if (!app.Environment.IsDevelopment())
 		{
 			app.Use(async (context, next) =>
 			{

--- a/JustDanceNextPlus/Properties/launchSettings.json
+++ b/JustDanceNextPlus/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "http": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
@@ -13,7 +13,7 @@
     "https": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
@@ -23,7 +23,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -31,7 +31,7 @@
     "Container (Dockerfile)": {
       "commandName": "Docker",
       "launchBrowser": true,
-      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/scalar",
       "environmentVariables": {
         "ASPNETCORE_HTTPS_PORTS": "8081",
         "ASPNETCORE_HTTP_PORTS": "8080"
@@ -42,7 +42,7 @@
     "WSL": {
       "commandName": "WSL2",
       "launchBrowser": true,
-      "launchUrl": "https://localhost:443/swagger",
+      "launchUrl": "https://localhost:443/scalar",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_URLS": "https://localhost:443;http://localhost:5084"

--- a/JustDanceNextPlus/Services/TagService.cs
+++ b/JustDanceNextPlus/Services/TagService.cs
@@ -143,7 +143,7 @@ public class TagService(LocalizedStringService localizedStringService, IServiceP
 
 public class TagDatabase
 {
-	public OrderedDictionary<Guid, Tag> Tags { get; set; } = [];
+	public System.Collections.Generic.OrderedDictionary<Guid, Tag> Tags { get; set; } = [];
 	public List<Guid> IsPresentInSongLibrary { get; set; } = [];
 	public List<Guid> IsPresentInSongPageDetails { get; set; } = [];
 }


### PR DESCRIPTION
This PR changes the project's .NET version from 8 to 9, and makes the change to using Scalar instead of Swagger.